### PR TITLE
Feature/deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 Reconsider is a minimalistic promise based database migration tool for rethinkdb that is meant to be called programmatically. Currently there is no CLI for it, though I do plan to add one in the near future.
- 
+
 Reconsider is not currently compatible with the native rethinkdb driver but instead requires [rethinkdbdash](https://github.com/neumino/rethinkdbdash).
 
 ## Installation
@@ -25,14 +25,14 @@ const tableName = 'my_table'
 module.exports = {
   up: function (r, logger) {
     logger.verbose(`Creating table ${tableName}.`)
-    
+
     return r.tableCreate(tableName).run()
       .then(() => r.table(tableName).indexCreate('some_property').run())
   },
-  
+
   down: function (r, logger) {
     logger.verbose(`Dropping table ${tableName}.`)
-    
+
     return r.tableDrop(tableName).run()      
   }
 }
@@ -92,12 +92,12 @@ recon.migrateUp()
 ```
 
 One consequence of Reconsider's lack of error catching is that an error in any migration will prevent all subsequent migrations from running. This, too, is intended behavior, since database migrations will more often than not rely on changes introduced by previous migrations. Since no automatic rollback is performed, and since all successful migrations will still register, `migrateUp` and `migrateDown` can safely be called again once the problem has been resolved.
- 
-This should also encourage the user to write small migrations that change one thing at a time, as opposed to huge migration files with several chained `.then`s. 
+
+This should also encourage the user to write small migrations that change one thing at a time, as opposed to huge migration files with several chained `.then`s.
 
 ### Logging
 Reconsider will output various messages to stdout by default, using `console.log`, `console.info` and `console.warn` as appropriate. All output is categorized into one of the following log levels: `debug`, `verbose`, `info`, `warn`, `error`. Minimum log level can be set via the `logLevel` config option.
- 
+
 ``` js
 // Use built in logger, don't output anything below "info" level (default config)
 const recon = new Reconsider(r, {
@@ -108,7 +108,7 @@ const recon = new Reconsider(r, {
 // Disable logging
 const recon = new Reconsider(r, { db: 'my_database' }, false)
 ```
- 
+
 Alternatively, you can provide a custom logger implementation, e.g. an instance of [winston](https://github.com/winstonjs/winston) or similar. When doing so, the provided object must implement methods for all supported log levels. Note that setting a `logLevel` via the config object will have no effect in this case, since Reconsider will assume that your logger as already been configured appropriately.
 
 ```js
@@ -118,7 +118,7 @@ const recon = new Reconsider(r, { db: 'my_database' }, myLoggerInstance)
 ```
 
 ## API Docs
-API documentation is in [jsdoc](https://github.com/jsdoc3/jsdoc) format and can be found in `src/Reconsider.js`. 
+Official API documentation lives [here](https://daerion.github.io/reconsider).
 
 ## Author
 [Michael Smesnik](https://github.com/daerion)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,16 @@
   "description": "A promise based database migration tool for rethinkdb",
   "main": "dist/Reconsider.js",
   "scripts": {
-    "test": "mocha --require test/util/babel-register"
+    "test": "mocha --require test/util/babel-register",
+    "lint": "standard \"src/**/*.js\" \"test/**/*.js\"",
+    "validate": "npm ls",
+    "preversion": "git checkout master && git pull && npm ls",
+    "docs": "mkdir -p docs && jsdoc -c .jsdoc.json src/",
+    "deploy-docs": "gh-pages -d docs && rm -rf docs",
+    "postpublish": "npm run docs && npm run deploy-docs",
+    "publish-patch": "npm run preversion && npm version patch && git push origin master --tags && npm publish",
+    "publish-minor": "npm run preversion && npm version minor && git push origin master --tags && npm publish",
+    "publish-major": "npm run preversion && npm version major && git push origin master --tags && npm publish"
   },
   "repository": {
     "type": "git",
@@ -20,25 +29,35 @@
     "bluebird": "^3.3.4"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-eslint": "^5.0.0",
-    "babel-plugin-syntax-async-functions": "^6.5.0",
-    "babel-plugin-syntax-object-rest-spread": "^6.5.0",
-    "babel-plugin-transform-regenerator": "^6.6.5",
-    "babel-polyfill": "^6.7.2",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-register": "^6.7.2",
+    "babel-cli": "^6.9.0",
+    "babel-eslint": "^6.0.4",
+    "babel-plugin-syntax-async-functions": "^6.8.0",
+    "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+    "babel-plugin-transform-regenerator": "^6.9.0",
+    "babel-polyfill": "^6.9.1",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-register": "^6.9.0",
     "chai": "^3.5.0",
-    "eslint": "^2.4.0",
-    "eslint-config-standard": "^5.1.0",
-    "eslint-plugin-promise": "^1.1.0",
+    "eslint": "^2.11.1",
+    "eslint-config-standard": "^5.3.1",
+    "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-standard": "^1.3.2",
-    "mocha": "^2.4.5"
+    "gh-pages": "^0.11.0",
+    "git-validate": "^2.1.4",
+    "jsdoc": "^3.4.0",
+    "minami": "^1.1.1",
+    "mocha": "^2.4.5",
+    "rethinkdbdash": "^2.3.6"
   },
   "peerDependencies": {
     "rethinkdbdash": "^2.2.18"
   },
   "standard": {
     "parser": "babel-eslint"
-  }
+  },
+  "pre-commit": [
+    "validate",
+    "lint",
+    "test"
+  ]
 }


### PR DESCRIPTION
hello:

thanks for the great package.  i noticed there could be some possible improvements in the package.json.  some of these changes are opinionated propositions, but have shown to be super helpful in a series of packages I've published and worked with in ampersand-js.  hopefully you'll find these useful.
# problem statements
- jsdoc & rethinkdbdash dependencies are missing 
- docs aren't persisted to the web on-module publish (user's have to download the repo and open the html)
- linting, testing, and package-validation could benefit from being run on every commit (quality control!)
- dependencies are out of date
# solution
- add missing deps
- auto-generate and publish docs to the web on-publish
  - add `postpublish` script that deploys docs!
  - ref: http://cdaringe.github.io/reconsider/index.html
- add `git-validate` to support `pre-commit` tasks (re: lint/test/validate oncommit)
- update dependencies
- add git friendly auto-versioning+publish scripts
  - e.g. `npm run publish-patch` would bump the patch version, push a tagged release to github, and publish to npm.
